### PR TITLE
Specify xpinyin version in setup.py to make bopomofo work correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='bopomofo',
       license='MIT',
       long_description=read('README.rst'),
       packages=['bopomofo'],
-      install_requires=['xpinyin'],
+      install_requires=['xpinyin==0.5.5'],
 
       # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[


### PR DESCRIPTION
Hi, antfu 😀

When I tried to:
```python
print(to_bopomofo(u'為什麼會這樣'))
```

it raised an error from line 64 in `__init__.py`:
```
TypeError: get_pinyin() got an unexpected keyword argument 'show_tone_marks'
```

Therefore, I temporarily modified line 64 on my local to avoid the error:
```python
return _pinyin.get_pinyin(chars, '|', tone_marks=tones).split('|')
```

It actually worked!
However, my terminal printed out an result that is not bopomofo:
```
wei4 shen2 me5 hui4 zhe4 yang4
```

I guessed maybe it's because of the version problem of this package's dependency,
so I tried to downgrade **xpinyin**'s version to 0.5.5 on my local.
And it really printed out the expected result:
```
ㄨㄟˋ ㄕㄣˊ ㄇㄜ˙ ㄏㄨㄟˋ ㄓㄜˋ ㄧㄤˋ
```

Hence, I consider that specifying the version to xpinyin in `setup.py` could help!
That's why I create this pull request 🙂